### PR TITLE
Corrected Migration.md to correct config Property

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -19,7 +19,7 @@ The simplest way to construct a client is via code:
 ```csharp
 var client = new OktaClient(new OktaClientConfiguration
 {
-    OrgUrl = "https://{{yourOktaDomain}}",
+    OktaDomain = "https://{{yourOktaDomain}}",
     Token = "{{yourApiToken}}"
 });
 ```


### PR DESCRIPTION
A config property used to be called OrgUrl is now OktaDomain (If not mistaken). Migration.md should reflect the current version I presume.